### PR TITLE
regexp for comment face ignored double quote characters

### DIFF
--- a/mumps.el
+++ b/mumps.el
@@ -93,7 +93,7 @@
 
   ;; create the thingy that we'll feed to font-lock-defaults
   (setq mumps-font-lock-keywords
-	`((,";.*$" . font-lock-comment-face)
+	`((,";[^\"]*$" . font-lock-comment-face)
           (,(regexp-opt (mapcar #'upcase mumps-keywords-abbrev)    'words) . font-lock-keyword-face)
           (,(regexp-opt (mapcar #'upcase mumps-keywords-full)      'words) . font-lock-keyword-face)
           (,(regexp-opt (mapcar #'downcase mumps-keywords-abbrev)  'words) . font-lock-keyword-face)


### PR DESCRIPTION
Note that this does break the highlighting for comments that contain double quotes:

i something q 2 ; quit with value "2"

...but in my experience there aren't too many of those. This seems like a reasonable enough heuristic, as it does handle situations in issue   #2 .